### PR TITLE
Uninett registry not publicly avialible so we use this selftest image…

### DIFF
--- a/ansible/roles/cluster_config/files/kube-selftest.yaml
+++ b/ansible/roles/cluster_config/files/kube-selftest.yaml
@@ -135,7 +135,7 @@ spec:
       serviceAccount: kube-selftest
       containers:
         - name: kube-selftest
-          image: registry.uninett.no/public/kube-selftest-service:v0.3
+          image: gurvin/kube-selftest-service:v0.3 
           livenessProbe:
             httpGet:
               path: /healthz


### PR DESCRIPTION
… instead. This might fix the locksmithd problem.